### PR TITLE
refactor: separate fzf shortcuts and brew packages from bash

### DIFF
--- a/bash/bash_shortcuts
+++ b/bash/bash_shortcuts
@@ -2,7 +2,7 @@
 # Copyright 2026 Ilja Heitlager
 # SPDX-License-Identifier: Apache-2.0
 
-# Bash + FZF shortcuts
+# Bash shortcuts
 
 # Color codes
 GREEN='\033[32m'
@@ -34,7 +34,7 @@ shortcut "Ctrl+_" "Undo last edit"
 
 echo ""
 echo "History:"
-shortcut "Ctrl+R" "Search command history (fzf)"
+shortcut "Ctrl+R" "Search command history"
 shortcut "Ctrl+P" "Previous command"
 shortcut "Ctrl+N" "Next command"
 shortcut "!!" "Repeat last command"
@@ -46,22 +46,3 @@ shortcut "Ctrl+C" "Cancel current command"
 shortcut "Ctrl+D" "Exit shell (EOF)"
 shortcut "Ctrl+Z" "Suspend current process (fg to resume)"
 shortcut "Ctrl+L" "Clear screen"
-
-echo ""
-echo "FZF - File & Directory Navigation:"
-shortcut "Ctrl+T" "Paste selected file path"
-shortcut "Alt+C" "Change directory (cd)"
-shortcut "**+Tab" "Fuzzy completion trigger"
-note "Examples: cd **<Tab>, vim **<Tab>"
-
-echo ""
-echo "FZF - Inside Interface:"
-shortcut "Ctrl+J/K" "Move down/up"
-shortcut "Ctrl+N/P" "Move down/up (alternative)"
-shortcut "Enter" "Select item"
-shortcut "Tab" "Toggle selection (multi-select)"
-shortcut "Shift+Tab" "Toggle selection upward"
-shortcut "Ctrl+A" "Select all"
-shortcut "Ctrl+D" "Deselect all"
-shortcut "Ctrl+/" "Toggle preview window"
-shortcut "Esc/Ctrl+C" "Cancel and exit"

--- a/fzf/bash_shortcuts
+++ b/fzf/bash_shortcuts
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ilja Heitlager
+# SPDX-License-Identifier: Apache-2.0
+
+# FZF shortcuts
+
+# Color codes
+GREEN='\033[32m'
+CYAN='\033[36m'
+RESET='\033[0m'
+
+shortcut() {
+    printf "  ${GREEN}%-20s${RESET} %s\n" "$1" "$2"
+}
+
+note() {
+    printf "  ${CYAN}Note: %s${RESET}\n" "$1"
+}
+
+echo "File & Directory Navigation:"
+shortcut "Ctrl+T" "Paste selected file path"
+shortcut "Ctrl+R" "Fuzzy search command history"
+shortcut "Alt+C" "Change directory (cd)"
+shortcut "**+Tab" "Fuzzy completion trigger"
+note "Examples: cd **<Tab>, vim **<Tab>"
+
+echo ""
+echo "Inside FZF Interface:"
+shortcut "Ctrl+J/K" "Move down/up"
+shortcut "Ctrl+N/P" "Move down/up (alternative)"
+shortcut "Enter" "Select item"
+shortcut "Tab" "Toggle selection (multi-select)"
+shortcut "Shift+Tab" "Toggle selection upward"
+shortcut "Ctrl+A" "Select all"
+shortcut "Ctrl+D" "Deselect all"
+shortcut "Ctrl+/" "Toggle preview window"
+shortcut "Esc/Ctrl+C" "Cancel and exit"

--- a/fzf/brew_packages
+++ b/fzf/brew_packages
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ilja Heitlager
+# SPDX-License-Identifier: Apache-2.0
+
+
+# brew installer helper, normally run this from 'dot'
+TMPPATH=$PATH
+PATH=/usr/local/bin:$PATH
+
+brew install fzf || brew upgrade fzf
+brew install fd || brew upgrade fd
+
+export PATH=$TMPPATH


### PR DESCRIPTION
## Summary
- Moved FZF-specific keyboard shortcuts from `bash/bash_shortcuts` into new `fzf/bash_shortcuts`
- Added `fzf/brew_packages` to install `fzf` and `fd` (used by FZF_DEFAULT_COMMAND in `fzf/bash_env`)
- Cleaned up `bash/bash_shortcuts` to contain only pure bash shortcuts

## Test plan
- [ ] Run `shortcuts fzf` to verify new fzf topic appears
- [ ] Run `shortcuts bash` to verify bash shortcuts are clean
- [ ] Run `dot` to verify fzf brew_packages is picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)