### PR TITLE
fix(dot): add set -e to exit on brew bundle failure

### DIFF
--- a/local/bin/dot
+++ b/local/bin/dot
@@ -7,6 +7,7 @@ BREWFILE="${XDG_DATA_HOME:-$HOME/.local/share}/Brewfile"
 
 # Trap Ctrl-C and exit cleanly
 trap 'echo ""; echo "❌ Installation interrupted by user"; exit 130' INT
+set -e
 
 print_usage() {
     local HELP="cat"


### PR DESCRIPTION
## Summary

- Add `set -e` after the `trap` line in `local/bin/dot`
- brew bundle failures were previously silently masked by the `exit 0` that followed
- Single one-line change; all risky patterns in the file already use `||` so they are exempt from `set -e`

## Test plan

- [x] `bash -n local/bin/dot` passes (syntax check)
- [x] `grep -n "set -e" local/bin/dot` shows exactly one match after the trap
- [x] No other lines changed

Fixes #45

🤖 *Generated with [Claude Code](https://claude.com/claude-code)*