### PR TITLE
feat(osx): machine profile selection for power management

### DIFF
--- a/osx/install.sh
+++ b/osx/install.sh
@@ -19,15 +19,30 @@ if [ ! -d ~/tmp ]; then
 fi
 
 ###########################################################################
-# Power Management (Mac mini sensible defaults)
+# Power Management
 ###########################################################################
-echo "  Configuring power management defaults..."
-sudo pmset -a sleep 30            # Sleep after 30 min inactivity
-sudo pmset -a disksleep 10        # Spin down disks after 10 min
-sudo pmset -a displaysleep 10     # Display off after 10 min
-sudo pmset -a networkoversleep 0  # Keep network active during sleep (SSH, Wake-on-LAN)
-sudo pmset -a powernap 1          # Power Nap on (default)
-# Note: auto-trader launch.sh overrides these to never-sleep when agents are running
+echo "  Configuring power management for profile: ${MACHINE_PROFILE:-laptop}..."
+if [ "${MACHINE_PROFILE:-laptop}" = "workstation" ]; then
+  # Always-on server (Mac mini)
+  sudo pmset -a sleep 0             # Never sleep
+  sudo pmset -a disksleep 0         # Never spin down disks
+  sudo pmset -a displaysleep 15     # Display off after 15 min
+  sudo pmset -a standby 0           # Disable standby mode
+  sudo pmset -a networkoversleep 0  # Keep network active during sleep
+  sudo pmset -a powernap 1          # Power Nap on (background tasks, backups)
+  sudo pmset -a womp 1              # Wake on magic packet (Wake-on-LAN)
+  sudo pmset -a autorestart 1       # Auto-restart after power failure
+else
+  # Laptop defaults
+  sudo pmset -a sleep 30            # Sleep after 30 min inactivity
+  sudo pmset -a disksleep 10        # Spin down disks after 10 min
+  sudo pmset -a displaysleep 10     # Display off after 10 min
+  sudo pmset -a standby 1           # Enable standby
+  sudo pmset -a networkoversleep 0  # Keep network active during sleep
+  sudo pmset -a powernap 1          # Power Nap on
+  sudo pmset -a womp 0              # No wake on LAN
+  sudo pmset -a autorestart 0       # No auto-restart after power failure
+fi
 
 ###########################################################################
 # Macbook

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -15,6 +15,8 @@ starttime=$(date +"%s")
 FORCE_GIT=false
 SKIP_BREW=false
 
+MACHINE_PROFILE_FILE="$HOME/.config/dotfiles/machine_profile"
+
 # Show help using bat if available (pattern from local/lib/shell-common.sh)
 _show_help() {
     if command -v bat &>/dev/null; then
@@ -32,9 +34,10 @@ Usage: bootstrap [OPTIONS]
   configures git, installs Homebrew packages, and links dotfiles.
 
 OPTIONS
-  -g, --git       Force regeneration of ~/.local/gitconfig
-      --no-brew   Skip Homebrew package installation
-  -h, --help      Show this help message
+  -g, --git              Force regeneration of ~/.local/gitconfig
+      --no-brew          Skip Homebrew package installation
+  -p, --profile PROFILE  Set machine profile: laptop, workstation, or auto
+  -h, --help             Show this help message
 
 EOF
 }
@@ -75,6 +78,63 @@ success () {
 fail () {
   printf "\r\033[2K  [\033[0;31mFAIL\033[0m] $1\n"
   echo ''
+}
+
+# Resolve machine profile: laptop or workstation
+_resolve_auto_profile () {
+  local hw_model
+  hw_model=$(sysctl -n hw.model 2>/dev/null || echo "")
+  if [[ "$hw_model" == Macmini* ]]; then
+    echo "workstation"
+  else
+    echo "laptop"
+  fi
+}
+
+setup_machine_profile () {
+  # Already set via environment — honour it and persist if new
+  if [ -n "$MACHINE_PROFILE" ]; then
+    if [ "$MACHINE_PROFILE" = "auto" ]; then
+      MACHINE_PROFILE=$(_resolve_auto_profile)
+      success "machine profile auto-detected: $MACHINE_PROFILE"
+    else
+      success "machine profile from environment: $MACHINE_PROFILE"
+    fi
+    mkdir -p "$(dirname "$MACHINE_PROFILE_FILE")"
+    echo "$MACHINE_PROFILE" > "$MACHINE_PROFILE_FILE"
+    export MACHINE_PROFILE
+    return
+  fi
+
+  # Already persisted from a previous run
+  if [ -f "$MACHINE_PROFILE_FILE" ]; then
+    MACHINE_PROFILE=$(cat "$MACHINE_PROFILE_FILE")
+    success "machine profile loaded: $MACHINE_PROFILE"
+    export MACHINE_PROFILE
+    return
+  fi
+
+  # Ask the user
+  echo ""
+  user "  What is the role of this machine?\n"
+  printf "    1) laptop      (default: sleep/standby enabled)\n"
+  printf "    2) workstation (always-on: no sleep, wake-on-LAN)\n"
+  printf "    3) auto-detect (Mac mini → workstation, otherwise laptop)\n"
+  printf "\n"
+  user "  Enter choice [1/2/3, default: 1]: "
+  read -r profile_choice
+
+  case "$profile_choice" in
+    2) MACHINE_PROFILE="workstation" ;;
+    3) MACHINE_PROFILE=$(_resolve_auto_profile)
+       success "auto-detected profile: $MACHINE_PROFILE" ;;
+    *) MACHINE_PROFILE="laptop" ;;
+  esac
+
+  mkdir -p "$(dirname "$MACHINE_PROFILE_FILE")"
+  echo "$MACHINE_PROFILE" > "$MACHINE_PROFILE_FILE"
+  success "machine profile set: $MACHINE_PROFILE (saved to $MACHINE_PROFILE_FILE)"
+  export MACHINE_PROFILE
 }
 
 # Create XDG Base Directory structure
@@ -372,6 +432,10 @@ while [[ $# -gt 0 ]]; do
       SKIP_BREW=true
       shift
       ;;
+    -p|--profile)
+      MACHINE_PROFILE="$2"
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -384,6 +448,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 setup_xdg_dirs
+setup_machine_profile
 purge_stale_symlinks
 validate_config_structure
 setup_gitconfig $FORCE_GIT


### PR DESCRIPTION
## Summary

- Adds `MACHINE_PROFILE` (laptop|workstation) to select appropriate `pmset` power settings at bootstrap time
- Bootstrap prompts once on first run and persists the choice to `~/.config/dotfiles/machine_profile`
- Harvests current Mac mini always-on settings (no sleep, no disk sleep, wake-on-LAN, auto-restart)

## Changes

### Added
- `setup_machine_profile` function in `script/bootstrap` — prompts with 3 options (laptop, workstation, auto-detect), skips if already set or persisted
- `-p, --profile PROFILE` flag to `bootstrap` for non-interactive overrides
- Auto-detect logic via `sysctl hw.model`: Mac mini → workstation, otherwise laptop

### Changed
- `osx/install.sh` power section is now conditional on `$MACHINE_PROFILE`
- Laptop profile: sleep 30min, disksleep 10min, displaysleep 10min, standby enabled, no WoL
- Workstation profile: no sleep, no disksleep, displaysleep 15min, standby disabled, WoL + autorestart

## Testing

- [ ] Run `bootstrap --profile laptop` and verify laptop pmset values applied
- [ ] Run `bootstrap --profile workstation` and verify workstation pmset values applied
- [ ] Run `bootstrap` fresh (no persisted file) and verify prompt appears
- [ ] Run `bootstrap` again and verify prompt is skipped
- [ ] Run `MACHINE_PROFILE=auto bootstrap` on Mac mini and verify workstation auto-detected

---
Generated with [Claude Code](https://claude.ai/code)