### PR TITLE
fix(claude): use Edit(...) matchers for sensitive-path deny rules

### DIFF
--- a/claude/config/settings.json
+++ b/claude/config/settings.json
@@ -71,11 +71,11 @@
       "Bash(crontab:*)",
       "Bash(*LaunchAgents*)",
       "Bash(*LaunchDaemons*)",
-      "Write(~/.ssh/*)",
-      "Write(~/.aws/*)",
-      "Write(~/.config/secrets)",
-      "Write(/etc/*)",
-      "Write(~/.crontab)"
+      "Edit(~/.ssh/*)",
+      "Edit(~/.aws/*)",
+      "Edit(~/.config/secrets)",
+      "Edit(/etc/*)",
+      "Edit(~/.crontab)"
     ],
     "defaultMode": "auto"
   },


### PR DESCRIPTION
## Summary
- Deny rules for `~/.ssh`, `~/.aws`, `~/.config/secrets`, `/etc`, `~/.crontab` used `Write(path)` matchers, which the harness's file-permission checks don't match against.
- Switched them to `Edit(path)` matchers, which do cover all file-editing tools (Write, Edit, NotebookEdit).

## Test plan
- [x] Verified the harness warning referenced these exact rules and confirmed via `readlink`/inspection that `~/.claude/settings.json` symlinks to this file.