### PR TITLE
fix(pandoc): map box-drawing chars to ASCII in code blocks

### DIFF
--- a/pandoc/data/filters/unicode-to-latex.lua
+++ b/pandoc/data/filters/unicode-to-latex.lua
@@ -63,6 +63,16 @@ local map = {
   ["—"] = [[\textemdash{}]],
 }
 
+-- Box-drawing chars aren't in the monospace font used for verbatim/code
+-- environments, and LaTeX macros don't expand there, so fall back to
+-- plain ASCII instead of the \ensuremath map above.
+local box_map = {
+  ["─"] = "-", ["━"] = "-",
+  ["│"] = "|", ["┃"] = "|",
+  ["┌"] = "+", ["┐"] = "+", ["└"] = "+", ["┘"] = "+",
+  ["├"] = "+", ["┤"] = "+", ["┬"] = "+", ["┴"] = "+", ["┼"] = "+",
+}
+
 local function rewrite(text)
   local parts = {}
   local buf = ""
@@ -86,4 +96,24 @@ function Str(el)
   if #parts == 0 then return pandoc.Str("") end
   if #parts == 1 then return parts[1] end
   return parts
+end
+
+local function rewrite_box_chars(text)
+  local out = {}
+  for char in text:gmatch("[%z\1-\127\194-\244][\128-\191]*") do
+    out[#out+1] = box_map[char] or char
+  end
+  return table.concat(out)
+end
+
+function Code(el)
+  if FORMAT ~= "latex" then return end
+  el.text = rewrite_box_chars(el.text)
+  return el
+end
+
+function CodeBlock(el)
+  if FORMAT ~= "latex" then return end
+  el.text = rewrite_box_chars(el.text)
+  return el
 end


### PR DESCRIPTION
## Summary
- The monospace PDF font (lmmono10-regular) lacks box-drawing glyphs (U+2500 etc.), so ASCII-art diagrams inside fenced code blocks rendered as broken/blank characters.
- The existing `Str()` handler only processes prose text via `\ensuremath{}` LaTeX macros, which don't expand inside verbatim/Code environments.
- Added dedicated `Code()`/`CodeBlock()` handlers that substitute box-drawing chars for plain ASCII (`-`, `|`, `+`) via literal text replacement.

## Test plan
- [x] Ran pandoc directly against a sample doc with prose Unicode math and a code-block box-drawing diagram — prose still converts via `\ensuremath`, code-block box chars now render as `+`/`-`/`|`.